### PR TITLE
Get rid of the "bracketed paste"; instead, remove empty lines always on Scala 3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "fi.aalto.cs.replace"
-version = "1.2.0"
+version = "1.2.1"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,3 +31,7 @@ intellijPlatform {
         }
     }
 }
+
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.WARN
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 <idea-plugin>
     <id>fi.aalto.cs.replace</id>
     <name>REPLace</name>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <vendor>LeTech</vendor>
 
     <description>

--- a/src/main/resources/messages/resources.properties
+++ b/src/main/resources/messages/resources.properties
@@ -10,7 +10,6 @@ ui.repl.notification.notFound.message=REPLace could not detect the module.
 ### Scala
 ui.repl.console.name=REPL for {0}
 ui.repl.console.scala.repl=Scala REPL
-ui.repl.console.scala.repl.replacePrompt=
 ui.repl.console.scala.repl.extended=Enhanced Scala REPL
 ui.repl.console.welcome.shortcutMissing=SHORTCUT MISSING
 ui.repl.console.welcome.autoImport.single.message=Auto-imported package [{0}] for your convenience.

--- a/src/main/scala/fi/aalto/cs/replace/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/replace/Repl.scala
@@ -45,7 +45,6 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module):
   // We need this here because the overridden ConsoleExecuteAction needs to determine whether
   // the console is hosting a Scala 3 REPL or something else
   val isScala3REPL: Boolean              = ModuleUtils.isScala3Module(module)
-  val isScalaVersionLessThan3_4_2: Boolean = ModuleUtils.isScalaVersionLessThan(module, "3.4.2")
 
   override def print(text: String, contentType: ConsoleViewContentType): Unit =
     var updatedText = text

--- a/src/main/scala/fi/aalto/cs/replace/utils/ModuleUtils.scala
+++ b/src/main/scala/fi/aalto/cs/replace/utils/ModuleUtils.scala
@@ -58,9 +58,6 @@ object ModuleUtils:
           imports.mkString(", ")
         )
 
-  def getAndHidePrompt(@NotNull originalText: String): String =
-    MyBundle.message("ui.repl.console.scala.repl.replacePrompt", originalText)
-
   def getUpdatedText(
       @NotNull module: Module,
       @NotNull commands: List[String],
@@ -158,9 +155,6 @@ object ModuleUtils:
   def isScala3Module(module: Module): Boolean =
     module.hasLibrary(library => library.getPresentableName.contains("scala-sdk-3"))
 
-  def isScalaVersionLessThan(module: Module, version: String): Boolean =
-    module.hasLibrary(library => getScalaVersion(library.getPresentableName).exists(_.lessThan(version)))
-
   extension (module: Module)
     private def hasLibrary(predicate: OrderEntry => Boolean): Boolean =
       ModuleRootManager
@@ -168,18 +162,6 @@ object ModuleUtils:
         .orderEntries()
         .librariesOnly()
         .exists(predicate)
-
-  private def getScalaVersion(libraryName: String): Option[Version] =
-    if libraryName.contains("scala-sdk-") then
-      Some(libraryName.split('-').last)
-    else
-      None
-
-  private class Version(private val nums: Seq[Int]):
-    def lessThan(that: Version): Boolean = Ordering.Implicits.seqOrdering.lt(this.nums, that.nums)
-  end Version
-
-  private given Conversion[String, Version] = (s: String) => Version(s.split('.').map(_.toIntOption.getOrElse(0)))
 
   private class ExistsRootPolicy(p: OrderEntry => Boolean) extends RootPolicy[Boolean]:
     override def visitOrderEntry(orderEntry: OrderEntry, value: Boolean): Boolean = value || p(orderEntry)

--- a/src/main/scala/org/jetbrains/plugins/scala/console/replace/ConsoleExecuteAction.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/console/replace/ConsoleExecuteAction.scala
@@ -17,41 +17,6 @@ import org.jetbrains.plugins.scala.console.actions.ScalaConsoleExecuteAction
 import org.jetbrains.plugins.scala.extensions.inWriteAction
 
 class ConsoleExecuteAction extends ScalaConsoleExecuteAction:
-  // We achieve proper multiline support by surrounding the REPL commands by special
-  // ANSI sequences indicating "bracketed paste". We exploit the fact that Scala 3 REPL
-  // uses the JLine 3 library, which explicitly supports the bracketed paste sequences
-
-  // However, Scala 3.4.2 updated the JLine library to a version that disabled the bracketed paste
-  // for dumb terminals.
-  // As a workaround, we remove empty lines from the input to avoid the issue.
-
-  // "Bracketed paste" means that newlines encountered in the string surrounded by paste markers
-  // should not be treated as end-of-statement markers, but rather mere parts of the statement.
-  // See https://cirw.in/blog/bracketed-paste for details.
-  private val BeginPaste = "\u001b[200~".getBytes
-  private val EndPaste   = "\u001b[201~".getBytes
-
-  // This is a "feature" of JLine - it has support for various terminals, but for IntelliJ console
-  // there isn't one, and therefore JLine defaults to "DumbTerminal", which is a terminal with no
-  // special features.
-  // When inserting bracketed paste sequences, the JLine library scans the input for the
-  // "bracketed paste end" sequence by reading from the terminal in 64-byte chunks.
-  // JLine erroneously blocks until the whole chunk is read; therefore, we need to pad the data
-  // to 64 characters to appease JLine.
-  // (This only occurs for DumbTerminals)
-  private val JLineBufferLength = 64
-
-  private def padTextToBlockLength(text: String): Array[Byte] =
-    var userInputBytes: Array[Byte] = text.getBytes
-    val contentLength               = userInputBytes.length + EndPaste.length
-
-    // We pad the input with some "neutral" character - a one that will have no side effects
-    // even if we add fifty of these. Space seems to be a good candidate.
-    if contentLength % JLineBufferLength != 0 then
-      userInputBytes = userInputBytes ++
-        Array.fill[Byte](JLineBufferLength - (contentLength % JLineBufferLength))(' ')
-
-    userInputBytes
 
   override def actionPerformed(e: AnActionEvent): Unit =
     val editor = e.getData(CommonDataKeys.EDITOR)
@@ -65,8 +30,8 @@ class ConsoleExecuteAction extends ScalaConsoleExecuteAction:
     val text     = document.getText
 
     // We should perform our multiline fixing only for our custom REPL that is running Scala 3.
-    // Non-A+ REPLs or those that host Scala 2 should not be modified.
-    // Additionally, if the text has no newlines, we don't need to do the bracketed paste.
+    // REPLs that host Scala 2 should not be modified.
+    // Additionally, if the text has no newlines, we don't need to modify it.
     if !console.isInstanceOf[Repl]
       || !console.asInstanceOf[Repl].isScala3REPL
       || !text.exists(c => c == '\n' || c == '\r')
@@ -91,20 +56,12 @@ class ConsoleExecuteAction extends ScalaConsoleExecuteAction:
         editor.getDocument.setText("")
     )
 
-    // the "start paste" sequence has to be in a separate write call, otherwise JLine won't
-    // pick it up properly; it seems to be yet another quirk of JLine and DumbTerminal
     val outputStream = processHandler.getProcessInput
     if outputStream != null then
-      if console.asInstanceOf[Repl].isScalaVersionLessThan3_4_2 then
-        outputStream.write(BeginPaste)
-        outputStream.flush()
-        outputStream.write(padTextToBlockLength(text) ++ EndPaste ++ "\n".getBytes)
-        outputStream.flush()
-      else
-        // Empty lines end the statement prematurely, so we remove them
-        val withoutEmptyLines = text.split("\n").filter(_.nonEmpty).mkString("\n")
-        outputStream.write((withoutEmptyLines + "\n").getBytes)
-        outputStream.flush()
+      // Empty lines end the statement prematurely, so we remove them
+      val withoutEmptyLines = text.split("\n").filter(_.nonEmpty).mkString("\n")
+      outputStream.write((withoutEmptyLines + "\n").getBytes)
+      outputStream.flush()
 
     console.textSent(text)
 


### PR DESCRIPTION
Our much beloved "bracketed paste" solution to properly handle multiline input only works with versions of JLine that no modern version of Scala 3 uses anymore. So, there's no good reason to keep that "hack" in our codebase.

Previously, we used bracketed paste for Scala versions "less than" 3.4.2 but recently some new releases of Scala 3.3.x has also updated their JLine versions. Thus, if we wanted to provide "proper multiline support" for those (old) versions of Scala 3 that still allow it, it would require more complex logic than just "less than 3.4.2".

So, the workaround solution of PR #5 (see that PR for more details) is applied to all Scala 3 consoles.